### PR TITLE
Hotfix: error when trying to load map series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+rubem
+
 # Qt for Python
 .qt_for_python
 

--- a/plugin/dialog/_tab_climate.py
+++ b/plugin/dialog/_tab_climate.py
@@ -1,3 +1,8 @@
+try:
+    from ..utils.series import splitDirFilePrefix
+except ImportError:
+    from utils.series import splitDirFilePrefix
+
 # Climate tab
 def setPrecipitationSeriesFilePath(self):
     """Define the project's Precipitation folder file.
@@ -12,7 +17,7 @@ def setPrecipitationSeriesFilePath(self):
         caption="Select Rainfall Series File", filter="(*.001);;All Files(*)"
     )
     if filePath:
-        tmpDir, tmpPrefix = self.splitDirFilePrefix(filePath)
+        tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
         self.config.set("DIRECTORIES", "prec", tmpDir)
         self.config.set("FILENAME_PREFIXES", "prec_prefix", tmpPrefix)
         self.lineEdt_Precipitation.setText(filePath)
@@ -32,7 +37,7 @@ def setEvapotranspirationSeriesFilePath(self):
         filter="(*.001);;All Files(*)",
     )
     if filePath:
-        tmpDir, tmpPrefix = self.splitDirFilePrefix(filePath)
+        tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
         self.config.set("DIRECTORIES", "etp", tmpDir)
         self.config.set("FILENAME_PREFIXES", "etp_prefix", tmpPrefix)
         self.lineEdt_EvapoTranspiration.setText(filePath)
@@ -52,7 +57,7 @@ def setKpSeriesFilePath(self):
         filter="(*.001);;All Files(*)",
     )
     if filePath:
-        tmpDir, tmpPrefix = self.splitDirFilePrefix(filePath)
+        tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
         self.config.set("DIRECTORIES", "kp", tmpDir)
         self.config.set("FILENAME_PREFIXES", "kp_prefix", tmpPrefix)
         self.lineEdt_PanCoefficientKp.setText(filePath)

--- a/plugin/dialog/_tab_landuse.py
+++ b/plugin/dialog/_tab_landuse.py
@@ -1,3 +1,8 @@
+try:
+    from ..utils.series import splitDirFilePrefix
+except ImportError:
+    from utils.series import splitDirFilePrefix
+
 # Land Use tab
 # Land Use Series
 def setLandUseSeriesFilePath(self):
@@ -13,7 +18,7 @@ def setLandUseSeriesFilePath(self):
         caption="Select Land Use Series File", filter="(*.001);;All Files(*)"
     )
     if filePath:
-        tmpDir, tmpPrefix = self.splitDirFilePrefix(filePath)
+        tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
         self.config.set("DIRECTORIES", "landuse", tmpDir)
         self.config.set("FILENAME_PREFIXES", "landuse_prefix", tmpPrefix)
         self.lineEdt_LandUseSeries.setText(filePath)
@@ -33,7 +38,7 @@ def setNDVISeriesFilePath(self):
         caption="Select NDVI Series File", filter="(*.001);;All Files(*)"
     )
     if filePath:
-        tmpDir, tmpPrefix = self.splitDirFilePrefix(filePath)
+        tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
         self.config.set("DIRECTORIES", "ndvi", tmpDir)
         self.config.set("FILENAME_PREFIXES", "ndvi_prefix", tmpPrefix)
         self.lineEdt_NDVISeries.setText(filePath)

--- a/plugin/dialog/_worker.py
+++ b/plugin/dialog/_worker.py
@@ -16,7 +16,10 @@ except ImportError:
 def setRunState(self):
     """Invoke the model's standalone executable including the configuration file generated from user input as an argument in the CLI."""
     # Use the standalone executable file of the model present in the plugin's root directory
-    self.modelFilePath = os.path.join(self.plugin_dir, "rubem", "rubem.exe")
+    self.modelFilePath = os.path.join(
+        self.plugin_dir, os.pardir, os.pardir, "rubem", "rubem.exe"
+    )
+    # raise Exception(self.modelFilePath)
 
     if self.hasFilledAllFields():
         self.updateConfigFromGUI()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the _Title_ above. -->

**Checklist:**
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Description**

The error in question occurred because when invoking the method as in previous versions of the code, via `self.splitDirFilePrefix(filePath)`. This method has now become a function and must be invoked after importing the respective module that contains it:

```python
from utils.series import splitDirFilePrefix

[...]
tmpDir, tmpPrefix = splitDirFilePrefix(filePath)
[...]
```

**Related Issue**

#119 

**Motivation and Context**

This change is required because it prevents the user from loading map series data into the project, which prevents the model from running because it is missing mandatory information.

**How Has This Been Tested**

I manually checked the operation on my workstation. I also inserted the changes into an installation on @LINAMARIAOSORIO 's workstation and we verified correct operation.
