### PR TITLE
Hotfix:  fix var name typo #123

### DIFF
--- a/plugin/dialog/_message_boxes.py
+++ b/plugin/dialog/_message_boxes.py
@@ -35,7 +35,7 @@ def getUserRetQGISCurProj(self):
         QMessageBox.Ok | QMessageBox.Cancel,
         QMessageBox.Ok,
     )
-    return responseS
+    return response
 
 
 def getUserRetDirNotEmpty(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the _Title_ above. -->

**Checklist:**
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Description**

A typo in the variable name that contained the return of the method that gets the user response was the cause of the problem. Simply correcting the typo fixed the problem.

**Related Issue**

#123 

**Motivation and Context**

This error prevents the window management and the open project from working correctly.

**How Has This Been Tested**

I manually checked the operation on my workstation. 