### PR TITLE
Fix Results tab not being activated upon completion of standalone executable

### DIFF
--- a/plugin/dialog/__init__.py
+++ b/plugin/dialog/__init__.py
@@ -182,7 +182,7 @@ class RUBEMHydrologicalDialog(QDialog, Ui_RUBEMHydrological):
         setSoilMoistureGenerateFile,
     )
     from ._tab_results import populateMapSeriesTree, populateTimeSeriesTree
-    from ._worker import setRunState, reportExecutionLog, reportProgress, runLongTask
+    from ._worker import setRunState, reportExecutionLog, reportProgress, runLongTask, handleFinished
     from ._graph_plot import plotTimeSeriesData, plotWrapper
     from ._map_canvas import canvasHandler
     from ._help_info import aboutHandler, helpHandler

--- a/plugin/dialog/_worker.py
+++ b/plugin/dialog/_worker.py
@@ -1,4 +1,5 @@
 import os
+from textwrap import dedent
 
 from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtWidgets import QMessageBox
@@ -56,17 +57,22 @@ def handleFinished(self, exit_code):
         self.populateTimeSeriesTree()
         QgsMessageLog.logMessage("RUBEM execution finished successfully!", "RUBEM Hydrological", level=Qgis.Success)        
     else:
-        self.textBrowser_log.append("\n# RUBEM execution finished with errors.")
-        self.textBrowser_log.append("\n# Check the log for more details.")
-        self.textBrowser_log.append("\n# If you need help, visit http://rubem-hydrological.rtfd.io/")
+        self.textBrowser_log.append(dedent("""\n
+            # RUBEM execution finished with errors!
+            # Check the log for more details.
+            # If you need help, visit http://rubem-hydrological.rtfd.io/"""
+        ))
+        self.progressBar.setStyleSheet("QProgressBar::chunk ""{""background-color: red;""}")
         QgsMessageLog.logMessage("RUBEM execution finished with errors.", "RUBEM Hydrological", level=Qgis.Critical)
 
 def runLongTask(self):
     """Configure QProcess."""
+    self.progressBar.setStyleSheet("")
     self.progressBar.setRange(0, 100)
     self.worker = RUBEMStandaloneWorker(self.command)
     self.worker.logUpdated.connect(self.reportExecutionLog)
     self.worker.errorUpdated.connect(self.reportExecutionLog)
+    self.worker.finished.connect(self.handleFinished)
     self.worker.finished.connect(self.worker.deleteLater)
     self.worker.progress.connect(self.reportProgress)   
     self.worker.finished.connect(lambda: self.btn_Run.setEnabled(True))

--- a/plugin/utils/workers.py
+++ b/plugin/utils/workers.py
@@ -19,7 +19,6 @@
 
 """RUBEM Hydrological plugin thread workers code."""
 
-from qgis.core import QgsMessageLog
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess
 
 class RUBEMStandaloneWorker(QObject):
@@ -33,6 +32,7 @@ class RUBEMStandaloneWorker(QObject):
 
     def run(self):
         self.process.start(self.command[0], self.command[1:])
+        self.process.waitForStarted()
 
     def handle_stdout(self):
         while self.process.canReadLine():
@@ -53,8 +53,11 @@ class RUBEMStandaloneWorker(QObject):
         if data: 
             self.errorUpdated.emit(data)
 
-    def handle_finished(self, exit_code, exit_status):
-        self.finished.emit(exit_code)
+    def handle_finished(self, exit_code):
+        if (exit_code == QProcess.NormalExit):
+            self.finished.emit(0)
+        else:
+            self.finished.emit(1)
 
     def kill(self):
         self.process.kill()


### PR DESCRIPTION
### Checklist
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] ~~Added **tests** for changed code.~~
- [ ] ~~Updated **documentation** for changed code.~~

### Description

- This pull request addresses an issue in the RUBEM QGIS Plugin where the `handleFinished` function was not being called upon the completion of the standalone executable `rubem.exe`. The changes involve explicitly connecting the finished signal of `RUBEMStandaloneWorker` to the `handleFinished` function.

### Related Issue

- Resolve #131.

### Motivation and Context

- The `handleFinished` function is responsible for handling the completion of the task, affecting the status messages displayed to the user and the enabling of certain UI elements. Without this fix, the user does not receive a success or error message in the log, and UI elements expected to be enabled upon completion remain disabled. This change is essential for a correct and user-friendly operation of the plugin.

### How Has This Been Tested

- The changes were tested by running several model simulations using the plugin and checking that the `handleFinished` function was correctly triggered upon completion, with the expected changes in the user interface. All tests passed successfully, and the plugin now behaves as expected.
