### PR TITLE
Fix `plotTimeSeriesData function` to use numpy arrays for plotting

### DIFF
--- a/plugin/report/plotter.py
+++ b/plugin/report/plotter.py
@@ -35,6 +35,7 @@ lw_cycle = cycler(lw=[1, 2, 1, 2, 1])
 # mk_cycle = cycler(marker=['.', ',', 'o', 'v','^'])
 sty_cycle = ls_cycle + color_cycle + lw_cycle
 
+
 # TODO: Add docstring information and comments
 def plotTimeSeriesData(sourceFile, plotDict, startDate, endDate):
 
@@ -57,13 +58,11 @@ def plotTimeSeriesData(sourceFile, plotDict, startDate, endDate):
     ax.set_prop_cycle(sty_cycle)
 
     for col in df.columns.difference(["Dates"]):
-        ax.plot(df["Dates"], df[col], label=col)
+        ax.plot(df["Dates"].to_numpy(), df[col].to_numpy(), label=col)
 
     ax.xaxis.set_tick_params(which="major", size=10, width=2, direction="in", top="on")
     ax.xaxis.set_tick_params(which="minor", size=7, width=2, direction="in", top="on")
-    ax.yaxis.set_tick_params(
-        which="major", size=10, width=2, direction="in", right="on"
-    )
+    ax.yaxis.set_tick_params(which="major", size=10, width=2, direction="in", right="on")
     ax.yaxis.set_tick_params(which="minor", size=7, width=2, direction="in", right="on")
     plt.xticks(rotation=45)
     plt.grid(True, which="both")


### PR DESCRIPTION
### Checklist
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] ~~Added **tests** for changed code.~~
- [ ] ~~Updated **documentation** for changed code.~~

### Description

- Used numpy arrays (`DataFrame.to_numpy()`) for plotting.

### Related Issue

- Resolve #135.

### How Has This Been Tested

- Manual testing was performed by:
  - Setting the provided sample configuration file;
  - Executing RUBEM with provided sample dataset using the configuration file of the previous step;
  - Opening any tabular result to display its graph;
  - Verifying the output against expected results.

### Aditional Information

- For more details about the solution see [ValueError: Multi-dimensional indexing (e.g. `obj[:, None]`) is no longer supported. Convert to a numpy array before indexing instead](https://stackoverflow.com/a/77093952) and [`pandas.DataFrame.values` warning and recomendation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.values.html);

### Acknowledgements

- @LINAMARIAOSORIO
